### PR TITLE
Feature proposal: close modal on keydown Escape

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import disableScroll from 'disable-scroll';
 
@@ -54,6 +54,21 @@ const Modal: React.FC<ModalProps> = ({ children, isOpen = false, close, elementI
   if (isOpen === false) {
     return null;
   }
+  const handleEscKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      if (evt.code === 'Escape') {
+        close();
+      }
+    },
+    [close]
+  );
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKeyDown);
+    };
+  }, []);
   return createPortal(
     <div style={wrapperStyle}>
       <div style={maskStyle} onClick={close} />


### PR DESCRIPTION
This PR is just a feature proposal, so If you don't think it is needed, please feel free to close this PR.

## Motivation

I think modal should be closed when `Esc` key is pressed. For example. `<dialog />` (on web standard) and `<Modal />` component in Material-UI is closed with `Esc` key.

- dialog: https://developer.mozilla.org/ja/docs/Web/HTML/Element/dialog
- material-ui modal: https://material-ui.com/components/modal/