### PR TITLE
Fix: webpack resolve extensions tsx -> .tsx

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   plugins: [htmlWebpackPlugin],
   resolve: {
-    extensions: ['.js', '.jsx', '.ts', 'tsx'],
+    extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },
   devServer: {
     port: 3001,


### PR DESCRIPTION
https://github.com/microcmsio/react-hooks-use-modal/blob/5ba01139ae1b7b418183da8d7bbf1ed6ce3709ac/webpack.config.js#L31

With the current version, `hoge.tsx` will not be resolved with `./hoge` module path, because webpack will try to search `./hoge.js` or `./hoge.jsx` or `./hoge.ts` or `./hogetsx` 