### PR TITLE
Improve keyboard accessibility.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import disableScroll from 'disable-scroll';
-import { useOverlay } from './useOverlay';
+import React, { useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useKeyDown } from './useKeyDown';
 
 export interface ModalProps {
   children: React.ReactNode;
@@ -53,8 +53,7 @@ const containerStyle: React.CSSProperties = {
 };
 
 const Modal: React.FC<ModalProps> = ({ children, isOpen = false, onOverlayClick, elementId = 'root' }) => {
-  const ref = useRef<HTMLDivElement>(null);
-  useOverlay(isOpen, close, ref);
+  const [ref] = useKeyDown<HTMLDivElement>(isOpen, close);
 
   if (isOpen === false) {
     return null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,9 +60,9 @@ const Modal: React.FC<ModalProps> = ({ children, isOpen = false, onOverlayClick,
     return null;
   }
   return createPortal(
-    <div role="dialog" aria-modal style={wrapperStyle}>
+    <div style={wrapperStyle}>
       <div style={overlayStyle} onClick={onOverlayClick} />
-      <div ref={ref} style={containerStyle}>{children}</div>
+      <div role="dialog" aria-modal={isOpen} ref={ref} style={containerStyle}>{children}</div>
     </div>,
     document.getElementById(elementId) as HTMLElement
   );
@@ -71,18 +71,21 @@ const Modal: React.FC<ModalProps> = ({ children, isOpen = false, onOverlayClick,
 export const useModal: UseModal = (elementId = 'root', options = {}) => {
   const { preventScroll = false, closeOnOverlayClick = true } = options;
   const [isOpen, setOpen] = useState<boolean>(false);
+
   const open = useCallback(() => {
     setOpen(true);
     if (preventScroll) {
       disableScroll.on();
     }
   }, [setOpen, preventScroll]);
+
   const close = useCallback(() => {
     setOpen(false);
     if (preventScroll) {
       disableScroll.off();
     }
   }, [setOpen, preventScroll]);
+
   const onOverlayClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
     if (closeOnOverlayClick) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ const Modal: React.FC<ModalProps> = ({ children, isOpen = false, onOverlayClick,
   return createPortal(
     <div style={wrapperStyle}>
       <div style={overlayStyle} onClick={onOverlayClick} />
-      <div role="dialog" aria-modal={isOpen} ref={ref} style={containerStyle}>{children}</div>
+      <div role="dialog" aria-modal={isOpen} ref={ref} style={containerStyle} tabIndex={0}>{children}</div>
     </div>,
     document.getElementById(elementId) as HTMLElement
   );

--- a/src/useKeyDown.tsx
+++ b/src/useKeyDown.tsx
@@ -1,14 +1,18 @@
-import { RefObject, useEffect } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 
-export function useOverlay(
+export const useKeyDown = <T extends HTMLElement>(
   isOpen: boolean,
   close: () => void,
-  ref: RefObject<HTMLDivElement>
-): void {
+): [RefObject<T>] => {
+  const dialogRef = useRef<T>(null);
+  const lastFocusedRef = useRef<Element | null>(null);
+
   useEffect(() => {
     if (!isOpen) {
-      return;
+      return
     }
+    lastFocusedRef.current = document.activeElement;
+    dialogRef.current?.focus();
 
     const handleKeydown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -19,17 +23,17 @@ export function useOverlay(
       if (event.key === 'Tab') {
         event.preventDefault();
 
-        if (ref.current === null) {
+        if (dialogRef.current === null) {
           return;
         }
 
         // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
         const focusableDialogElements: HTMLElement[] = Array.from(
-          ref.current.querySelectorAll(
+          dialogRef.current.querySelectorAll(
             'button, a[href], input:not([type="hidden"]), select, details > summary:first-child, textarea, [tabindex]:not([tabindex="-1"]), [contenteditable]'
           )
         );
-        const focusables = focusableDialogElements.concat(ref.current)
+        const focusables = focusableDialogElements.concat(dialogRef.current)
 
         const currentIndex = focusables.findIndex(
           (element) => element === document.activeElement
@@ -61,6 +65,9 @@ export function useOverlay(
 
     return () => {
       document.body.removeEventListener('keydown', handleKeydown);
+      lastFocusedRef.current instanceof HTMLElement && lastFocusedRef.current?.focus();
     };
-  }, [isOpen, close, ref]);
+  }, [isOpen, close]);
+
+  return [dialogRef];
 }

--- a/src/useOverlay.tsx
+++ b/src/useOverlay.tsx
@@ -23,13 +23,13 @@ export function useOverlay(
           return;
         }
 
-        // https://gomakethings.com/how-to-get-the-first-and-last-focusable-elements-in-the-dom/
         // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
-        const focusables: HTMLElement[] = Array.from(
+        const focusableDialogElements: HTMLElement[] = Array.from(
           ref.current.querySelectorAll(
             'button, a[href], input:not([type="hidden"]), select, details > summary:first-child, textarea, [tabindex]:not([tabindex="-1"]), [contenteditable]'
           )
         );
+        const focusables = focusableDialogElements.concat(ref.current)
 
         const currentIndex = focusables.findIndex(
           (element) => element === document.activeElement


### PR DESCRIPTION
Hi, thanks for this useful react hooks.
It would be great if we could move focus with keyboard operations, therefore I try implement it.

# Overview
- The role attribute, aria-modal append to dialog element.
- Implement focus loop of a dialog.
- Open a dialog then entire dialog focused and close a dialog then last focused element.

# Reference
- https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html