### PR TITLE
Add `initialValue` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ render(<App />, document.getElementById('root'));
 
 ## Syntax
 
-### [ModalComponent, openFunc, closeFunc, isOpenBool] = useModal(domNode?, { preventScroll?, focusTrapOptions?, components? })
+### [ModalComponent, openFunc, closeFunc, isOpenBool] = useModal(domNode?, { initialValue?, preventScroll?, focusTrapOptions?, components? })
 
 `ModalComponent`
 Type: React.FC<{ title?: React.ReactNode; description?: React.ReactNode, children?: React.ReactNode }>
@@ -56,6 +56,11 @@ Optional.
 Default value is 'root'.
 Modal component uses React-Portal.
 You can specify the output destination domNode with this argument
+
+`initialValue`
+Optional.
+Default value is false.
+This is useful when you want to mount the modal in an open position.
 
 `preventScroll`
 Optional to prevent scrolling while modal is open.

--- a/examples-routes.js
+++ b/examples-routes.js
@@ -1,6 +1,10 @@
 module.exports = [
   { path: '/', title: 'useModal example' },
   {
+    path: '/initial-value',
+    title: 'useModal with initialValue option example',
+  },
+  {
     path: '/prevent-scroll',
     title: 'useModal with preventScroll option example',
   },

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -5,6 +5,7 @@ import routes from '../../examples-routes';
 
 import { Modal as CommonModal } from './js';
 import { ModalWrapper as ComponentsOptionModal } from './js/components-option';
+import { Modal as InitialValueModal } from './js/initial-value';
 import { ModalWrapper as ModalProviderModal } from './js/modal-config';
 import { Modal as PreventScrollModal } from './js/prevent-scroll';
 
@@ -14,6 +15,9 @@ const CurrentModal = () => {
       .replace(/^\/react-hooks-use-modal/, '')
       .replace(/\/$/, '')
   ) {
+    case '/initial-value': {
+      return <InitialValueModal />;
+    }
     case '/prevent-scroll': {
       return <PreventScrollModal />;
     }

--- a/examples/src/js/initial-value/index.tsx
+++ b/examples/src/js/initial-value/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { useModal } from '../../../../src';
+
+const modalStyle: React.CSSProperties = {
+  backgroundColor: '#fff',
+  padding: '60px 100px',
+  borderRadius: '10px',
+};
+
+export const Modal = () => {
+  const [Modal, open, close, isOpen] = useModal('root', {
+    initialValue: true,
+  });
+
+  return (
+    <div>
+      <div>Modal is Open? {isOpen ? 'Yes' : 'No'}</div>
+      <button onClick={open}>OPEN</button>
+      <Modal>
+        <div style={modalStyle}>
+          <h1>Title</h1>
+          <p>This is a customizable modal.</p>
+          <button onClick={close}>CLOSE</button>
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export interface ModalProps {
 }
 
 export interface UseModalOptions {
+  initialValue?: boolean;
   preventScroll?: boolean;
   focusTrapOptions?: FocusTrapOptions;
   components?: {
@@ -49,6 +50,7 @@ export type UseModal = (
 ];
 
 const defaultOptions: Required<UseModalOptions> = {
+  initialValue: false,
   preventScroll: false,
   focusTrapOptions: {},
   components: {},
@@ -56,11 +58,11 @@ const defaultOptions: Required<UseModalOptions> = {
 
 export const useModal: UseModal = (elementId = 'root', options) => {
   const modalConfig = useModalConfig();
-  const { preventScroll, focusTrapOptions, components } = useMemo(
+  const { initialValue, preventScroll, focusTrapOptions, components } = useMemo(
     () => Object.assign({}, defaultOptions, modalConfig, options),
     [modalConfig, options]
   );
-  const [isOpen, setOpen] = useState<boolean>(false);
+  const [isOpen, setOpen] = useState<boolean>(initialValue);
 
   const open = useCallback(() => {
     setOpen(true);


### PR DESCRIPTION
## Summary

Added `initialValue` option.
This is useful when you want to mount a modal in an open state.

For example, without this option, if you want to keep it open as the initial state, you can do the following
```jsx
const App = () => {
  const [Modal, open, close, isOpen] = useModal('root');

  useEffect(() => {
    open();
  }, [open]);

  return (
    <div>
      <div>Modal is Open? {isOpen ? 'Yes' : 'No'}</div>
      <button onClick={open}>OPEN</button>
      <Modal>
        <div>
          <h1>Title</h1>
          <p>This is a customizable modal.</p>
          <button onClick={close}>CLOSE</button>
        </div>
      </Modal>
    </div>
  );
};
```

This use of `useEffect` is not as good as it should be.
The easiest way to avoid it is to allow the options on the `useModal` side to have initial values.