### PR TITLE
Add `additionalProps` props that can be specified in Modal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ render(<App />, document.getElementById('root'));
 ### [ModalComponent, openFunc, closeFunc, isOpenBool] = useModal(domNode?, { preventScroll?, focusTrapOptions?, components? })
 
 `ModalComponent`
-Type: React.FC<{ title?: React.ReactNode; description?: React.ReactNode, children?: React.ReactNode }>
+Type: React.FC<{ title?: React.ReactNode; description?: React.ReactNode, children?: React.ReactNode, additionalProps?: Record<string, unknown> }>
 Modal component that displays children in the screen center.
-If you specify `title` and `description`, you must implement custom components with the `components` option's `Modal` property and render in them.
+If you specify `title` and `description`, `additionalProps` you must implement custom components with the `components` option's `Modal` property and render in them.
+See EXAMPLE below for details.
+https://github.com/microcmsio/react-hooks-use-modal/blob/master/examples/src/js/components-option/index.tsx
 
 `openFunc`
 A function to open modal.

--- a/examples/src/js/components-option/index.tsx
+++ b/examples/src/js/components-option/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ModalProvider, useModal } from '../../../../src';
+import { ModalProps, ModalProvider, useModal } from '../../../../src';
 
 const Modal = () => {
   const [Modal, open, close, isOpen] = useModal('root');
@@ -46,6 +46,80 @@ const ModalWithOverrideOptions = () => {
   );
 };
 
+type AdditionalProps = {
+  footer: React.ReactNode;
+};
+interface OverrideModalProps extends ModalProps<AdditionalProps> {}
+const OverrideModal: React.FC<OverrideModalProps> = ({
+  title,
+  description,
+  children,
+  additionalProps,
+}) => {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        padding: '60px 100px',
+        backgroundColor: 'fff',
+        borderRadius: '10px',
+      }}
+    >
+      <div
+        style={{
+          marginBottom: '60px',
+        }}
+      >
+        {title && <h1>{title}</h1>}
+        {description && <p>{description}</p>}
+      </div>
+      {additionalProps?.footer && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '60px',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            backgroundColor: 'rgba(0,0,0,0.1)',
+          }}
+        >
+          {additionalProps.footer}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+};
+
+const ModalWithAdditionalProps = () => {
+  const [Modal, open, close, isOpen] = useModal('root', {
+    components: {
+      Modal: OverrideModal, // The type of `additionalProps` that can be specified for `Modal` is automatically determined according to the type of `components.Modal` props.
+    },
+  });
+
+  return (
+    <div style={{ marginTop: '40px' }}>
+      <div>
+        Modal with `additionalProps` option applied is Open?{' '}
+        {isOpen ? 'Yes' : 'No'}
+      </div>
+      <button onClick={open}>OPEN</button>
+      <Modal
+        title="Title"
+        description="This is a customizable modal."
+        additionalProps={{ footer: <button onClick={close}>CLOSE</button> }}
+      >
+        {''}
+      </Modal>
+    </div>
+  );
+};
+
 export const ModalWrapper = () => {
   return (
     <ModalProvider
@@ -72,6 +146,7 @@ export const ModalWrapper = () => {
     >
       <Modal />
       <ModalWithOverrideOptions />
+      <ModalWithAdditionalProps />
     </ModalProvider>
   );
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -6,7 +6,7 @@ import { ModalProps, OverlayProps, WrapperProps } from '..';
 import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
-interface ModalWrapperProps {
+interface ModalWrapperProps<T extends Record<string, unknown>> {
   children: React.ReactNode;
   isOpen: boolean;
   close: () => void;
@@ -18,11 +18,12 @@ interface ModalWrapperProps {
   components: {
     Wrapper: React.ComponentType<WrapperProps>;
     Overlay: React.ComponentType<OverlayProps>;
-    Modal: React.ComponentType<ModalProps>;
+    Modal: React.ComponentType<ModalProps<T>>;
   };
+  additionalProps?: T;
 }
 
-export const ModalWrapper: React.FC<ModalWrapperProps> = ({
+export const ModalWrapper = <T extends Record<string, unknown>>({
   children,
   isOpen,
   close,
@@ -32,7 +33,8 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
   preventScroll,
   focusTrapOptions,
   components,
-}) => {
+  additionalProps,
+}: ModalWrapperProps<T>): React.ReactElement | null => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const _focusTrapOptions = useMemo(
     () => ({
@@ -59,7 +61,12 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
         tabIndex={-1}
         style={{ position: 'relative' }}
       >
-        <components.Modal title={title} description={description} close={close}>
+        <components.Modal
+          title={title}
+          description={description}
+          close={close}
+          additionalProps={additionalProps}
+        >
           {children}
         </components.Modal>
       </div>

--- a/src/components/ModalProvider.tsx
+++ b/src/components/ModalProvider.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { UseModalOptions } from '..';
 import { ModalConfigContext } from '../hooks/useModalConfig';
 
-interface ModalProviderProps extends UseModalOptions {
+interface ModalProviderProps<T extends Record<string, unknown>>
+  extends UseModalOptions<T> {
   children?: React.ReactNode;
 }
 
-export const ModalProvider: React.FC<ModalProviderProps> = ({
+export const ModalProvider = <T extends Record<string, unknown>>({
   children,
   ...props
-}) => {
+}: ModalProviderProps<T>): React.ReactElement | null => {
   return (
     <ModalConfigContext.Provider value={props}>
       {children}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,46 +15,53 @@ export interface WrapperProps {
 
 export interface OverlayProps {}
 
-export interface ModalProps {
+export interface ModalProps<T extends Record<string, unknown>> {
   title?: React.ReactNode;
   description?: React.ReactNode;
   close: () => void;
   children: React.ReactNode;
+  additionalProps?: T;
 }
 
-export interface UseModalOptions {
+export interface UseModalOptions<T extends Record<string, unknown>> {
   preventScroll?: boolean;
   focusTrapOptions?: FocusTrapOptions;
   components?: {
     Wrapper?: React.ComponentType<WrapperProps>;
     Overlay?: React.ComponentType<OverlayProps>;
-    Modal?: React.ComponentType<ModalProps>;
+    Modal?: React.ComponentType<ModalProps<T>>;
   };
 }
 
-export interface ModalWrapperProps {
+export interface ModalWrapperProps<T extends Record<string, unknown>> {
   title?: React.ReactNode;
   description?: React.ReactNode;
   children: React.ReactNode;
+  additionalProps?: T;
 }
 
-export type UseModal = (
-  elementId?: string,
-  options?: UseModalOptions
-) => [
-  ModalWrapper: React.FC<ModalWrapperProps>,
+export type UseModalResult<T extends Record<string, unknown>> = [
+  ModalWrapper: React.FC<ModalWrapperProps<T>>,
   open: () => void,
   close: () => void,
   isOpen: boolean
 ];
 
-const defaultOptions: Required<UseModalOptions> = {
+export type UseModal<T extends Record<string, unknown>> = (
+  elementId?: string,
+  options?: UseModalOptions<T>
+) => UseModalResult<T>;
+
+const defaultOptions: Required<UseModalOptions<{}>> = {
   preventScroll: false,
   focusTrapOptions: {},
   components: {},
 };
 
-export const useModal: UseModal = (elementId = 'root', options) => {
+export const useModal = <T extends Record<string, unknown>>(
+  elementId = 'root',
+  options?: UseModalOptions<T>
+): UseModalResult<T> => {
   const modalConfig = useModalConfig();
   const { preventScroll, focusTrapOptions, components } = useMemo(
     () => Object.assign({}, defaultOptions, modalConfig, options),
@@ -74,8 +81,8 @@ export const useModal: UseModal = (elementId = 'root', options) => {
   const Overlay = components.Overlay ?? DefaultOverlay;
   const Modal = components.Modal ?? DefaultModal;
 
-  const _ModalWrapper: React.FC<ModalWrapperProps> = useCallback(
-    ({ title, description, children }) => {
+  const _ModalWrapper: React.FC<ModalWrapperProps<T>> = useCallback(
+    ({ title, description, children, additionalProps }) => {
       return (
         <ModalWrapper
           isOpen={isOpen}
@@ -90,6 +97,7 @@ export const useModal: UseModal = (elementId = 'root', options) => {
             Overlay,
             Wrapper,
           }}
+          additionalProps={additionalProps}
         >
           {children}
         </ModalWrapper>


### PR DESCRIPTION
## Summary

Allow passing props named `additionalProps` to the `ModalWrapper` returned by `useModal`.
This is necessary to pass props other than the default props (title, description, children) when implementing a modal component that can be customized with the components option.

```jsx
const Modal = ({ title, description, children, additionalProps }) => {
  return (
    <div>
      <div>
        {title && <h1>{title}</h1>}
        {description && <p>{description}</p>}
      </div>
      {additionalProps?.footer && <div>{additionalProps.footer}</div>}
      {children}
    </div>
  );
};
```

## Main Changes

I have changed it so that additionalProps are added to the props passed to Modal.

We have also changed the implementation around types in various ways so that the type of `additionalProps` is inferred.
The types that were originally exported are left as they are, so there are no destructive changes.