### PR TITLE
proof of concept dialog element

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -33,7 +33,7 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
   focusTrapOptions,
   components,
 }) => {
-  const dialogRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const _focusTrapOptions = useMemo(
     () => ({
       onDeactivate: close,
@@ -52,8 +52,9 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
   return createPortal(
     <components.Wrapper>
       <components.Overlay />
-      <div
+      <dialog
         ref={dialogRef}
+        id="dialog-poc"
         role="dialog"
         aria-modal="true"
         tabIndex={-1}
@@ -62,7 +63,7 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
         <components.Modal title={title} description={description} close={close}>
           {children}
         </components.Modal>
-      </div>
+      </dialog>
     </components.Wrapper>,
     document.getElementById(elementId) as HTMLElement
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,8 +62,9 @@ export const useModal: UseModal = (elementId = 'root', options) => {
   );
   const [isOpen, setOpen] = useState<boolean>(false);
 
-  const open = useCallback(() => {
-    setOpen(true);
+  const open = useCallback(async () => {
+    await setOpen(true);
+    document.getElementById('dialog-poc').showModal();
   }, [setOpen]);
 
   const close = useCallback(() => {


### PR DESCRIPTION
Here's a proof of concept : this is the bare minimum changes in order to use dialog HTML element instead of div.

- Notice the hard-coded id to get the dialog element and use showModal() function: I should use a [forwardRef hook](https://reactjs.org/docs/forwarding-refs.html) in order to have the open() function managed by the parent element. As it is too complicated to use for me (and maybe I'm missing something simplier), I'ld rather show you something dirty but that works :)
- Notice the await before setOpen(true), that allows the async function to wait for React to render the modal before running the "showModal()" following line.

Also I'm sorry but I don't know how to open a pull request on a non-existing branch on your side; so please feel free to revoke this PR and try on my side.

closes #49 