### PR TITLE
Added future.d.ts

### DIFF
--- a/future.d.ts
+++ b/future.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/future';


### PR DESCRIPTION
# Summary
Added `future.d.ts` to the root because the type information is not applied when importing as shown below.

```ts
import { useModal } from 'react-hooks-use-modal/future';
```

