### PR TITLE
Set isModal to true by default

### DIFF
--- a/src/future/index.tsx
+++ b/src/future/index.tsx
@@ -81,6 +81,8 @@ export const useModal: UseModal = (options) => {
 
   const open: (options?: { isModal?: boolean }) => void = useCallback(
     (options = {}) => {
+      options.isModal = options.isModal ?? true;
+
       if (options.isModal) {
         ref.current?.showModal();
       } else {


### PR DESCRIPTION
## Summary
In the `open` function options, fixed `isModal` to be true by default.